### PR TITLE
CocoaPods からのインストール用の podspec を追加

### DIFF
--- a/Funiki.podspec
+++ b/Funiki.podspec
@@ -1,0 +1,13 @@
+Pod::Spec.new do |s|
+  s.name = 'Funiki'
+  s.version = '1.0.3'
+  s.summary = "The FUN'IKI Ambient Glasses SDK for iOS."
+  s.homepage = 'http://fun-iki.com/'
+  s.license = { :type => 'MIT', :file => 'LICENSE' }
+  s.ios.deployment_target = '8.0'
+  s.source = { :git => 'https://github.com/FUNIKImegane/FunikiSDK.git', :commit => '672c9bbb0fff2013e90ed25c70cfa527aba4479b' }
+  s.source_files  = 'FunikiSDK/*.{h,m}'
+  s.frameworks = 'CoreBluetooth', 'UIKit'
+  s.vendored_libraries = 'FunikiSDK/libFunikiSDK.a'
+  s.requires_arc = true
+end


### PR DESCRIPTION
## 概要

[CocoaPods](https://cocoapods.org) の podspec ファイルを追加しました。これにより、FunikiSDK をより簡単にプロジェクトに追加することができるようになります。
## 使用方法
### CocoaPods でのインストール

Podfile にて対象となる target に対して下記を記述し `pod install` を実行します。
swift プロジェクトにインストールする場合は `use_frameworks!` が必須となります。

```
pod 'Funiki', :git => 'https://github.com/FUNIKImegane/FunikiSDK.git'
```
### Swift プロジェクトでの使用方法

`Funiki` モジュールをインポートしてください。

```
@import Funiki
```
### Objective-C プロジェクトでの使用方法

`use_frameworks!` を指定した場合は `Funiki` モジュールをインポートしてください。

```
@import Funiki;
```

指定しなかった場合は必要な `Funiki/*.h` ヘッダをインポートしてください。

```
#import <Funiki/Funiki.h>
```
## 確認事項

podspec にはライブラリに関する概要、ライセンス等の各種情報の記載が必要となります。内容に問題ないか確認していただく必要があると思います。特にライブラリが使用可能な deployment_target のバージョンについては、仮で記述してありますのでライブラリのビルド環境に応じて修正が必要となります。

```
  s.summary = "The FUN'IKI Ambient Glasses SDK for iOS."
  s.homepage = 'http://fun-iki.com/'
  s.license = { :type => 'MIT', :file => 'LICENSE' }
  s.ios.deployment_target = '8.0'
```
## さらなる改善案
### バージョン指定

現状、FunikiSDK は tag でのリリース管理がされていませんので、コミットした podspec には最新のバージョンのコミットを指定してあります。

```
  s.version = '1.0.3'
  s.source = { :git => 'https://github.com/FUNIKImegane/FunikiSDK.git', :commit => '672c9bbb0fff2013e90ed25c70cfa527aba4479b' }
```

tag で各バージョンのリリースを管理していただき、下記のように podspec を修正することで、SDK の利用者はバージョンを明確に指定してプロジェクトに取り込むことができるようになります。

```
  s.version = '1.0.3'
  s.source = { :git => 'https://github.com/FUNIKImegane/FunikiSDK.git', :tag => s.version.to_s }
```

SDK をアップデートする際には tag の設定と、上記 podspec の `s.version` の更新が必要となります。
### CocoaPods への登録

[CocoaPods](https://cocoapods.org) に登録することで、サイトからのライブラリ検索ができるようになったり、Podfile への記述が簡単になります。

```
  pod 'Funiki', '~> 1.0.3'
```

登録する場合は、 podspec のライブラリに関する情報をより詳細にしておくことが望ましいでしょう。
